### PR TITLE
Make browser package fully compatable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
+        "lzma-js-simple": "^1.1.0",
         "lzma-native": "^8.0.6",
         "osu-classes": "^0.10.0"
       },
@@ -5705,6 +5706,11 @@
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
+    },
+    "node_modules/lzma-js-simple": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lzma-js-simple/-/lzma-js-simple-1.1.0.tgz",
+      "integrity": "sha512-5QY/o73DUHnrvJBRX9jQbjFGXna8L3sYuwy2lQvTAcCWhWbuS/5NyMwOzXrvh5psDFYbVctoJr5dMKENcJck9Q=="
     },
     "node_modules/lzma-native": {
       "version": "8.0.6",
@@ -12992,6 +12998,11 @@
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
+    },
+    "lzma-js-simple": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lzma-js-simple/-/lzma-js-simple-1.1.0.tgz",
+      "integrity": "sha512-5QY/o73DUHnrvJBRX9jQbjFGXna8L3sYuwy2lQvTAcCWhWbuS/5NyMwOzXrvh5psDFYbVctoJr5dMKENcJck9Q=="
     },
     "lzma-native": {
       "version": "8.0.6",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
+    "lzma-js-simple": "^1.1.0",
     "lzma-native": "^8.0.6",
     "osu-classes": "^0.10.0"
   }

--- a/src/browser/Utils/FileSystem.ts
+++ b/src/browser/Utils/FileSystem.ts
@@ -5,9 +5,13 @@ const browserFSOperation = function() {
 } as (...args: any[]) => any;
 
 export {
+  // fs
   browserFSOperation as existsSync,
   browserFSOperation as readFileSync,
   browserFSOperation as statSync,
   browserFSOperation as mkdirSync,
   browserFSOperation as writeFileSync,
+
+  // path
+  browserFSOperation as dirname,
 };

--- a/src/browser/Utils/LZMA.ts
+++ b/src/browser/Utils/LZMA.ts
@@ -1,0 +1,7 @@
+import { compress as _compress, decompress } from "lzma-js-simple";
+
+function compress(input: string, level: number, cb: (result: Buffer) => void) {
+  _compress(input, level as any, (result) => cb(Buffer.from(result)));
+}
+
+export const LZMA = () => ({ compress, decompress });

--- a/src/core/Decoders/Handlers/Replays/ReplayDecoder.ts
+++ b/src/core/Decoders/Handlers/Replays/ReplayDecoder.ts
@@ -1,4 +1,4 @@
-import { LZMA } from 'lzma-native';
+import { LZMA } from '../../../Utils/LZMA';
 import { ReplayFrame, LifeBarFrame } from 'osu-classes';
 import { Parsing } from '../../../Utils';
 

--- a/src/core/Encoders/BeatmapEncoder.ts
+++ b/src/core/Encoders/BeatmapEncoder.ts
@@ -1,5 +1,4 @@
-import { mkdirSync, writeFileSync } from '../Utils/FileSystem';
-import { dirname } from 'path';
+import { mkdirSync, writeFileSync, dirname } from '../Utils/FileSystem';
 import { IBeatmap } from 'osu-classes';
 
 import {

--- a/src/core/Encoders/Handlers/Replays/ReplayEncoder.ts
+++ b/src/core/Encoders/Handlers/Replays/ReplayEncoder.ts
@@ -1,4 +1,4 @@
-import { LZMA } from 'lzma-native';
+import { LZMA } from '../../../Utils/LZMA';
 import { ILifeBarFrame, IReplayFrame } from 'osu-classes';
 
 export abstract class ReplayEncoder {

--- a/src/core/Encoders/ScoreEncoder.ts
+++ b/src/core/Encoders/ScoreEncoder.ts
@@ -1,5 +1,4 @@
-import { mkdirSync, writeFileSync } from '../Utils/FileSystem';
-import { dirname } from 'path';
+import { mkdirSync, writeFileSync, dirname } from '../Utils/FileSystem';
 import { IScore } from 'osu-classes';
 import { ReplayEncoder, SerializationWriter } from './Handlers';
 

--- a/src/core/Encoders/StoryboardEncoder.ts
+++ b/src/core/Encoders/StoryboardEncoder.ts
@@ -1,5 +1,4 @@
-import { mkdirSync, writeFileSync } from '../Utils/FileSystem';
-import { dirname } from 'path';
+import { mkdirSync, writeFileSync, dirname } from '../Utils/FileSystem';
 import { Storyboard } from 'osu-classes';
 
 import {

--- a/src/node/Utils/FileSystem.ts
+++ b/src/node/Utils/FileSystem.ts
@@ -4,4 +4,6 @@ export {
   statSync,
   mkdirSync,
   writeFileSync,
-} from 'fs';
+} from "fs";
+
+export { dirname } from "path";

--- a/src/node/Utils/LZMA.ts
+++ b/src/node/Utils/LZMA.ts
@@ -1,0 +1,1 @@
+export { LZMA } from "lzma-native";


### PR DESCRIPTION
This replaces `lzma-native` in the browser build, and also overrides `path.dirname` in the browser