### PR TITLE
Remove extra step for restoring original X-position from osu!mania objects

### DIFF
--- a/src/core/Decoders/Handlers/Beatmaps/BeatmapGeneralDecoder.ts
+++ b/src/core/Decoders/Handlers/Beatmaps/BeatmapGeneralDecoder.ts
@@ -57,7 +57,7 @@ export abstract class BeatmapGeneralDecoder {
         break;
 
       case 'SampleSet':
-        beatmap.general.sampleSet = (SampleSet as any)[value];
+        beatmap.general.sampleSet = SampleSet[value as keyof typeof SampleSet];
         break;
 
       case 'LetterboxInBreaks':

--- a/src/core/Encoders/Handlers/Beatmaps/BeatmapHitObjectEncoder.ts
+++ b/src/core/Encoders/Handlers/Beatmaps/BeatmapHitObjectEncoder.ts
@@ -45,14 +45,6 @@ export abstract class BeatmapHitObjectEncoder {
         position ? position.y : 192,
       );
 
-      if (beatmap.mode === 3) {
-        const totalColumns = Math.trunc(Math.max(1, difficulty.circleSize));
-        const multiplier = Math.round(512 / totalColumns * 100000) / 100000;
-        const column = (hitObject as unknown as IHasPosition).startX;
-
-        startPosition.x = Math.ceil(column * multiplier) + Math.trunc(multiplier / 2);
-      }
-
       general.push(startPosition.toString());
       general.push(hitObject.startTime.toString());
       general.push(hitObject.hitType.toString());

--- a/src/core/Encoders/Handlers/Beatmaps/BeatmapTimingPointEncoder.ts
+++ b/src/core/Encoders/Handlers/Beatmaps/BeatmapTimingPointEncoder.ts
@@ -104,8 +104,9 @@ export abstract class BeatmapTimingPointEncoder {
     let customIndex = 0;
     let volume = 100;
 
+    // TODO: Needs a complete rework
     if (samplePoint !== null) {
-      sampleSet = (SampleSet as any)[samplePoint.sampleSet];
+      sampleSet = SampleSet[samplePoint.sampleSet as keyof typeof SampleSet];
       customIndex = samplePoint.customIndex;
       volume = samplePoint.volume;
     }


### PR DESCRIPTION
One of the main differences between this 
parser and osu!lazer is the way hit objects store information about their position. While osu!lazer discards unnecessary data during conversion, this parsers retains the original position between all modes. That's why we don't need to do that extra step to restore X position from column data.