### PR TITLE
Fix broken typings for TypeScript 4.7+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.6",
       "license": "MIT",
       "dependencies": {
-        "lzma-js-simple-v2": "^1.2.2"
+        "lzma-js-simple-v2": "^1.2.3"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -1689,7 +1689,6 @@
       "version": "20.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
       "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5011,9 +5010,12 @@
       "dev": true
     },
     "node_modules/lzma-js-simple-v2": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/lzma-js-simple-v2/-/lzma-js-simple-v2-1.2.2.tgz",
-      "integrity": "sha512-dHjXHlgcS8r2K+4t8kAycGE4xMVQxPzMTCrrYhaFEtQDmjXh/A7xq4D88oOfEtjTR9XFzTAML9AuBrm4jXLigA=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/lzma-js-simple-v2/-/lzma-js-simple-v2-1.2.3.tgz",
+      "integrity": "sha512-6kgy86Q3YLolV6dOwCqdQXg3V07e3XJJ6wqfrN8/s65mvCfqkr+jMJkfiSZNvk+u2ig+G8rLdtaoW/g1oJiwow==",
+      "dependencies": {
+        "@types/node": "^20.12.7"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.10",
@@ -6517,8 +6519,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -7971,7 +7972,6 @@
       "version": "20.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
       "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
-      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -10393,9 +10393,12 @@
       "dev": true
     },
     "lzma-js-simple-v2": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/lzma-js-simple-v2/-/lzma-js-simple-v2-1.2.2.tgz",
-      "integrity": "sha512-dHjXHlgcS8r2K+4t8kAycGE4xMVQxPzMTCrrYhaFEtQDmjXh/A7xq4D88oOfEtjTR9XFzTAML9AuBrm4jXLigA=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/lzma-js-simple-v2/-/lzma-js-simple-v2-1.2.3.tgz",
+      "integrity": "sha512-6kgy86Q3YLolV6dOwCqdQXg3V07e3XJJ6wqfrN8/s65mvCfqkr+jMJkfiSZNvk+u2ig+G8rLdtaoW/g1oJiwow==",
+      "requires": {
+        "@types/node": "^20.12.7"
+      }
     },
     "magic-string": {
       "version": "0.30.10",
@@ -11470,8 +11473,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "update-browserslist-db": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.1.6",
   "description": "A bundle of parsers for osu! file formats based on the osu!lazer source code.",
   "exports": {
+    "types": "./lib/index.d.ts",
     "node": {
       "import": "./lib/node.mjs",
       "require": "./lib/node.cjs"
@@ -40,7 +41,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lzma-js-simple-v2": "^1.2.2"
+    "lzma-js-simple-v2": "^1.2.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "es6",
-    "moduleResolution": "node",
+    "module": "ES6",
+    "moduleResolution": "Bundler",
     "outDir": "./dist",
     "rootDirs": ["./src/core", "./src/node"],
     "declaration": false,


### PR DESCRIPTION
Makes newer versions of TypeScript compatible with this library.
Fixes #23 