### PR TITLE
Fix: adjust package.json exports to be resolvable by newer typescript compiler versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "4.1.7",
   "description": "A bundle of parsers for osu! file formats based on the osu!lazer source code.",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "node": {
+    ".": {
+      "import": "./lib/browser.mjs",
+      "types": "./lib/index.d.ts"
+    },
+    "./node": {
       "import": "./lib/node.mjs",
       "require": "./lib/node.cjs"
-    },
-    "import": "./lib/browser.mjs"
+    }
   },
   "types": "./lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Ran into the issue of tsc (typescript 5.2.2) as well as vscode not being able to resolve the types due to the exports field not matching what the compiler expects. 
I plan to pr the same fix for the other packages as well if this gets accepted.
I'm not sure if this breaks anything for old typescript versions but confirmed that this works when installing the package locally when using typescript 5.2.2.